### PR TITLE
Fix GHA workflow to create PRs with pinned action versions

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -5,19 +5,23 @@ on:
     - cron: "30 3 * * *"
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   update:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install dependencies
         run: |
           pipx install poetry
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
           cache: "poetry"
@@ -26,14 +30,15 @@ jobs:
         run: |
           poetry install
 
-      - name: Run script and commit changes
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run script
         run: |
-          git config --local user.email "github-actions[bot]@users.noreply.github.com"
-          git config --local user.name "github-actions[bot]"
           poetry run python gen.py
-          git diff --quiet &&
-          git diff --staged --quiet ||
-          git commit -am "Update" &&
-          git push
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
+        with:
+          commit-message: "Update device list"
+          title: "Update device list"
+          body: "Automated update of Apple device list."
+          branch: auto-update
+          delete-branch: true


### PR DESCRIPTION
## Summary
- Add `permissions` block for `contents: write` and `pull-requests: write`
- Replace direct `git push` with `peter-evans/create-pull-request` action
- Pin all actions to commit hashes with latest patch versions

## Test plan
- [ ] Run workflow manually via `workflow_dispatch` and verify PR is created