### PR TITLE
Add Renovate for automated dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    "schedule:monthly"
+  ],
+  "minimumReleaseAge": "3 days",
+  "packageRules": [
+    {
+      "matchManagers": ["github-actions"],
+      "groupName": "GitHub Actions",
+      "automerge": true
+    },
+    {
+      "matchManagers": ["poetry"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "Python dependencies (non-major)",
+      "automerge": true
+    },
+    {
+      "matchManagers": ["poetry"],
+      "matchUpdateTypes": ["major"],
+      "groupName": null
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add Renovate configuration to automate dependency updates
- Monthly schedule with 3-day stability delay
- GitHub Actions updates grouped into a single PR (automerge)
- Python minor/patch updates grouped into a single PR (automerge)
- Python major updates as separate PRs for manual review