### PR TITLE
Disable Renovate dependency dashboard

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,7 @@
     "config:recommended",
     "schedule:monthly"
   ],
+  "dependencyDashboard": false,
   "minimumReleaseAge": "3 days",
   "packageRules": [
     {


### PR DESCRIPTION
## Summary
- Disable dependency dashboard issue creation by Renovate