### PR TITLE
Fix poetry install failure in Nightly Update CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,6 @@
+[tool.poetry]
+package-mode = false
+
 [project]
 name = "ios-devices"
 version = "0.1.0"


### PR DESCRIPTION
## Summary
- `pyproject.toml` に `package-mode = false` を追加
- Nightly Update ワークフローの `poetry install` が「No file/folder found for package ios-devices」で失敗していた問題を修正

## Test plan
- [x] Nightly Update ワークフローが正常に完了することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)